### PR TITLE
Updated doc for RCP_Emails\send(): $to param accepts arrays

### DIFF
--- a/includes/class-rcp-emails.php
+++ b/includes/class-rcp-emails.php
@@ -283,7 +283,7 @@ class RCP_Emails {
 	 * Send the email
 	 *
 	 * @since 2.7
-	 * @param string $to The To address
+	 * @param string|array $to The To address
 	 * @param string $subject The subject line of the email
 	 * @param string $message The body of the email
 	 * @param string|array $attachments Attachments to the email


### PR DESCRIPTION
As documented in wp_mail() the $to parameter accepts also an array, updated RCP_Emails::send() function documentation.

```
[...]
@global PHPMailer $phpmailer
@param string|array $to          Array or comma-separated list of email addresses to send message.
@param string       $subject     Email subject
[...]
```